### PR TITLE
Switch to camelcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Signature
 
 * `processName` A string, which is the name of the process
 * `metadata` An Object, which has key/value information
-* `disableConsoleLog` Boolean. Default false. If True, messages from `console.log` will not be picked up by overlock. 
+* `disableConsoleLog` Boolean. Default false. If True, messages from `console.log` will not be picked up by overlock.
 * `jsonReplacer` A custom function to pass to `JSON.stringify` when encoding state
 
 
@@ -39,7 +39,7 @@ Example:
 ol.log("This is a log message")
 
 // Log as device
-ol.log("This is as a different device", {log_as: "device123"})
+ol.log("This is as a different device", {logAs: "device123"})
 
 // Log with related device
 ol.log("This is associated with the other node too", {related: "device234"})
@@ -59,7 +59,7 @@ Signature:
 * `msg` A string, which contains a message to debug
 * `opts` An object with keys:
     * `level`: The log level (goes straight to agent API)
-    * `log_as`: Log as if the message were from another node
+    * `logAs`: Log as if the message were from another node
     * `related`: Log with an association
 
 `ol.error`, `ol.warn`, `ol.debug`, `ol.info` should all just be proxies to `log` with the log `level` set.
@@ -71,21 +71,21 @@ Lifecycle events can be logged to allow high level information and events to be 
 ```javascript
 
 // Lifecycle event
-ol.lifecycle_event("boot", "Booted up")
+ol.lifecycleEvent("boot", "Booted up")
 
 // For another device
-ol.lifecycle_event("network-disconnect", "Unexpected Disconnected!", {log_as: "device234"})
+ol.lifecycleEvent("network-disconnect", "Unexpected Disconnected!", {logAs: "device234"})
 
 ```
 
 Signature:
 
-`ol.lifecycle_event(type, msg, opts)`
+`ol.lifecycleEvent(type, msg, opts)`
 
 * `type` A string type for a supported or custom lifecycle event
 * `msg` A string which describes the event
 * `opts` An object with keys:
-    * `log_as`: Log as if the message were from another node
+    * `logAs`: Log as if the message were from another node
     * `related`: Log with an association
 
 ### Metadata
@@ -94,13 +94,13 @@ Allows storing of values about a node which do not change very often.
 
 ```javascript
 
-ol.update_metadata({version: "10.000"})
+ol.updateMetadata({version: "10.000"})
 
 ```
 
 Signature:
 
-`ol.update_metadata(values)`
+`ol.updateMetadata(values)`
 
 * `values` An object which contains the keys to merge in to the metadata. Values will be converted to strings, and Falsy values will be removed from metadata.
 
@@ -109,9 +109,9 @@ Signature:
 ```javascript
 
 // set a key
-ol.update_state({sensor: 120})
+ol.updateState({sensor: 120})
 
 // delete a key
-ol.delete_state({sensor: true})
+ol.deleteState({sensor: true})
 
 ```


### PR DESCRIPTION
Not sure whether `opts` `log_as` should actually stay as is to save additional processing?